### PR TITLE
Release 2018-08-20 II

### DIFF
--- a/custom_registration/views.py
+++ b/custom_registration/views.py
@@ -32,8 +32,14 @@ from .decorators import user_is_not_logged_in
 @method_decorator(user_is_not_logged_in, name='dispatch')
 class SignupView(FormView):
     form_class = SignupForm
-    success_url = reverse_lazy('studygroups_facilitator')
     template_name = 'custom_registration/signup.html'
+
+    def get_success_url(self):
+        # if there is a next URL defined, use that
+        if 'next' in self.request.GET:
+            return self.request.GET['next']
+        return reverse('studygroups_facilitator')
+        
 
     def form_valid(self, form):
         user = form.save(commit=False)

--- a/discourse_sso/views.py
+++ b/discourse_sso/views.py
@@ -40,9 +40,11 @@ def discourse_sso(request):
         'email': user.email,
         'external_id': user.id,
         'username': '{}_{}'.format(user.first_name, user.last_name),
-        'require_activation': 'true',
         'name': user.get_full_name(),
     }
+    if user.profile.email_confirmed_at is None:
+        # Let discourse also verify the email address
+        params['require_activation'] = 'true'
 
     return_payload = base64.encodebytes(bytes(parse.urlencode(params), 'utf-8'))
     h = hmac.new(key, return_payload, digestmod=hashlib.sha256)

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -6,7 +6,7 @@
   <div class="container">
       <h1>{% trans "Log in" %}</h1>
       {% url 'register' as signup_url %}
-      <p>{% blocktrans %}Or <a href="{{ signup_url }}">create account</a>{% endblocktrans %}</p>
+      <p>{% trans 'Or' %} <a href="{{ signup_url }}{% if request.GET.next %}?next={{ request.GET.next|urlencode }}{% endif %}">{% trans 'create account' %}</a></p>
       <p>{% trans "Your username is the email address you signed up with." %}</p>
     <form action="" method="POST">
       {% csrf_token %}


### PR DESCRIPTION
Discourse SSO improvements
- Redirect users back to discourse when signing up after following the login link from discourse
- Only require email validation for users on discourse if we haven't already validated their email