### PR TITLE
Release 2018-08-28

### DIFF
--- a/frontend/signup.jsx
+++ b/frontend/signup.jsx
@@ -17,3 +17,18 @@ ReactDOM.render(
   />,
   document.getElementById('div_id_mobile')
 );
+
+
+let otherGoalDiv = document.getElementById('div_id_goals_other');
+let goalInput = document.getElementById('id_goals');
+if (goalInput.value != 'Other'){
+  otherGoalDiv.style = 'display: none;';
+}
+goalInput.onchange = (e) => {
+  if (e.target.value == 'Other'){
+    otherGoalDiv.style = '';
+    document.getElementById('id_goals_other').required = true;
+  } else {
+    otherGoalDiv.style = 'display: none;';
+  }
+};

--- a/studygroups/management/commands/send_next_week_learner_surveys.py
+++ b/studygroups/management/commands/send_next_week_learner_surveys.py
@@ -1,0 +1,29 @@
+from django.core.management.base import BaseCommand, CommandError
+
+from studygroups.models import send_learner_survey
+from studygroups.models import StudyGroup
+
+import datetime
+from django.utils import timezone
+
+class Command(BaseCommand):
+    help = 'Send surveys to learners finishing in less than a week from now. This is to bridge the change in when surveys are sent and is not meant to be used otherwise.'
+
+    def handle(self, *args, **options):
+        # find all learner circles with the last meeting being less than a week in the future
+
+        now = timezone.now()
+        ## last :00, :15, :30 or :45 plus one week
+        last_15 = now.replace(minute=now.minute//15*15, second=0)
+        for study_group in StudyGroup.objects.published():
+            last_meeting = study_group.meeting_set.active().order_by('-meeting_date', '-meeting_time').first()
+
+            # send survey if last meeting is less than a week in the future
+            if last_meeting and last_15 - datetime.timedelta(minutes=15) <= last_meeting.meeting_datetime() and last_meeting.meeting_datetime() < last_15 + datetime.timedelta(days=7):
+                applications = study_group.application_set.active().filter(accepted_at__isnull=False).exclude(email='')
+                timezone.deactivate()
+
+                for application in applications:
+                    send_learner_survey(application)
+
+

--- a/studygroups/models.py
+++ b/studygroups/models.py
@@ -838,7 +838,18 @@ def report_data(start_time, end_time, team=None):
 
     feedback = Feedback.objects.filter(study_group_meeting__in=meetings)
 
+    active = any([
+        len(meetings) > 0,
+        len(feedback) > 0,
+        len(new_study_groups) > 0,
+        len(finished_study_groups) > 0,
+        len(new_facilitators) > 0,
+        len(new_courses) > 0,
+        len(signups) > 0,
+    ])
+
     report = {
+        'active': active,
         'meetings': meetings,
         'feedback': feedback,
         'study_groups': new_study_groups,
@@ -866,7 +877,9 @@ def send_weekly_update():
 
     for team in Team.objects.all():
         report_context = report_data(start_time, end_time, team)
-        # TODO check if there was any activity during this period. If not, discard the update
+        # If there wasn't any activity during this period discard the update
+        if report_context['active'] is False:
+            continue
         report_context.update(context)
         timezone.activate(pytz.timezone(settings.TIME_ZONE)) #TODO not sure what this influences anymore?
         translation.activate(settings.LANGUAGE_CODE)

--- a/studygroups/tasks.py
+++ b/studygroups/tasks.py
@@ -13,7 +13,7 @@ from studygroups.models import send_reminder
 from studygroups.models import send_weekly_update
 from studygroups.models import send_new_studygroup_email
 from studygroups.models import send_new_facilitator_email
-from studygroups.models import send_survey_reminder
+from studygroups.models import send_learner_surveys
 from studygroups.models import send_facilitator_survey
 from studygroups.models import send_last_week_group_activity
 
@@ -76,7 +76,7 @@ def send_new_studygroup_emails():
 def send_all_studygroup_survey_reminders():
     for study_group in StudyGroup.objects.published():
         translation.activate(settings.LANGUAGE_CODE)
-        send_survey_reminder(study_group)
+        send_learner_surveys(study_group)
 
 
 @shared_task

--- a/studygroups/tests/test_models.py
+++ b/studygroups/tests/test_models.py
@@ -22,7 +22,7 @@ from studygroups.models import send_reminder
 from studygroups.models import create_rsvp
 from studygroups.models import generate_all_meetings
 from studygroups.models import send_weekly_update
-from studygroups.models import send_survey_reminder
+from studygroups.models import send_learner_surveys
 from studygroups.models import send_facilitator_survey
 from studygroups.models import send_last_week_group_activity
 from studygroups.rsvp import gen_rsvp_querystring
@@ -532,13 +532,13 @@ class TestSignupModels(TestCase):
 
 
 
-    def test_send_survey_reminder(self):
+    def test_send_learner_surveys(self):
         now = timezone.now()
         sg = StudyGroup.objects.get(pk=1)
         sg.timezone = now.strftime("%Z")
         sg.start_date = datetime.date(2010, 1, 1)
         sg.meeting_time = datetime.time(18,0)
-        sg.end_date = sg.start_date + datetime.timedelta(weeks=5)
+        sg.end_date = sg.start_date + datetime.timedelta(weeks=6)
         sg.save()
         sg = StudyGroup.objects.get(pk=1)
         generate_all_meetings(sg)
@@ -560,24 +560,24 @@ class TestSignupModels(TestCase):
         mail.outbox = []
 
         last_meeting = sg.meeting_set.active().order_by('meeting_date', 'meeting_time').last()
-        self.assertEqual(last_meeting.meeting_date, datetime.date(2010, 2, 5))
-        self.assertEqual(last_meeting.meeting_time, datetime.time(18,0))
-        self.assertEqual(sg.meeting_set.active().count(), 6)
+        self.assertEqual(last_meeting.meeting_date, datetime.date(2010, 2, 12))
+        self.assertEqual(last_meeting.meeting_time, datetime.time(18))
+        self.assertEqual(sg.meeting_set.active().count(), 7)
         self.assertEqual(sg.application_set.active().count(), 2)
 
         # freeze time to 5 minutes before
         with freeze_time("2010-02-05 17:55:34"):
-            send_survey_reminder(sg)
+            send_learner_surveys(sg)
             self.assertEqual(len(mail.outbox), 0)
 
         # 10 minutes after start
         with freeze_time("2010-02-05 18:10:34"):
-            send_survey_reminder(sg)
+            send_learner_surveys(sg)
             self.assertEqual(len(mail.outbox), 0)
 
         # 25 minutes after start
         with freeze_time("2010-02-05 18:25:34"):
-            send_survey_reminder(sg)
+            send_learner_surveys(sg)
             self.assertEqual(len(mail.outbox), 2)
             self.assertIn('mail1@example.net', mail.outbox[0].to + mail.outbox[1].to)
             self.assertIn('mail2@example.net', mail.outbox[0].to + mail.outbox[1].to)
@@ -587,7 +587,7 @@ class TestSignupModels(TestCase):
         mail.outbox = []
         # 40 minutes after start
         with freeze_time("2010-02-05 18:40:34"):
-            send_survey_reminder(sg)
+            send_learner_surveys(sg)
             self.assertEqual(len(mail.outbox), 0)
 
 

--- a/studygroups/tests/test_models.py
+++ b/studygroups/tests/test_models.py
@@ -480,18 +480,20 @@ class TestSignupModels(TestCase):
         study_group = StudyGroup.objects.get(pk=1)
         meeting = Meeting()
         meeting.study_group = study_group
-        meeting.meeting_time = timezone.now().time()
-        meeting.meeting_date = timezone.now().date() - datetime.timedelta(days=1)
+        meeting.meeting_time = datetime.time(9)
+        meeting.meeting_date = datetime.date(2018, 8, 22)
         meeting.save()
 
         study_group = StudyGroup.objects.get(pk=2)
         meeting = Meeting()
         meeting.study_group = study_group
-        meeting.meeting_time = timezone.now().time()
-        meeting.meeting_date = timezone.now().date() - datetime.timedelta(days=1)
+        meeting.meeting_time = datetime.time(9)
+        meeting.meeting_date = datetime.date(2018, 8, 22)
         meeting.save()
 
-        send_weekly_update()
+        
+        with freeze_time("2018-08-28 10:01:00"):
+            send_weekly_update()
 
         self.assertEqual(len(mail.outbox), 2)
         self.assertEqual(mail.outbox[0].to[0], 'organ@team.com')
@@ -510,18 +512,19 @@ class TestSignupModels(TestCase):
         study_group = StudyGroup.objects.get(pk=1)
         meeting = Meeting()
         meeting.study_group = study_group
-        meeting.meeting_time = timezone.now().time()
-        meeting.meeting_date = timezone.now().date() - datetime.timedelta(days=15)
+        meeting.meeting_time = datetime.time(9)
+        meeting.meeting_date = datetime.date(2018, 8, 14)
         meeting.save()
 
         study_group = StudyGroup.objects.get(pk=2)
         meeting = Meeting()
         meeting.study_group = study_group
-        meeting.meeting_time = timezone.now().time()
-        meeting.meeting_date = timezone.now().date() - datetime.timedelta(days=15)
+        meeting.meeting_time = datetime.time(9)
+        meeting.meeting_date = datetime.date(2018, 8, 14)
         meeting.save()
 
-        send_weekly_update()
+        with freeze_time("2018-08-28 10:01:00"):
+            send_weekly_update()
 
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].to[0], 'admin@test.com')

--- a/templates/studygroups/email/learner_survey_reminder-subject.txt
+++ b/templates/studygroups/email/learner_survey_reminder-subject.txt
@@ -1,1 +1,1 @@
-{% load i18n %}{% trans "How did your learning circle go?" %}
+{% load i18n %}{% trans "How is you learning circle going?" %}

--- a/templates/studygroups/email/learner_survey_reminder.html
+++ b/templates/studygroups/email/learner_survey_reminder.html
@@ -3,88 +3,93 @@
 {% load i18n %}
 
 
-{% blocktrans %}
-
 <table>
   <tbody>
     <tr>
       <td>
         <p>Hi {{learner_name}},</p>
 
-        <p>Can you take a few minutes to let us know how your learning circle went? Your feedback - the good and the bad - will improve the learning circle program for learners and facilitators around the world.</p>
+        <p>{% trans "Can you take a few minutes to let us know how your learning circle is going? Your feedback - the good and the bad - will improve the learning circle program for learners and facilitators around the world." %}</p>
 
-        <p>Let’s start with what brought you here. When you signed up for the learning circle, you said that your primary goal was: <strong>{{learner_goal}}</strong>.</p>
-        <p>To what extent did you achieve this goal during the learning circle?</p>
+        {% if learner_goal %}
+        <p>{% blocktrans %}Let’s start with what brought you here. When you signed up for the learning circle, you said that your primary goal was: <strong>{{learner_goal}}</strong>.{% endblocktrans %}</p>
+
+        <p>{% trans "To what extent did you achieve this goal during the learning circle?" %}</p>
+        {% else %}
+        <p>{% blocktrans %}Share your feedback by clicking <a href="{{survey_url}}">this link</a>{% endblocktrans %}<p>
+        {% endif %}
       </td>
     </tr>
+
+    {% if learner_goal %}
+      <tr>
+        <td>
+          <table align="center" align="center" style="margin-top: 2rem; margin-bottom: 2rem;">
+            <tbody>
+              <tr>
+                <td>
+                  <table border="0" cellspacing="0" cellpadding="0" >
+                    <tbody>
+                      <tr>
+                        <td>
+                          <a href="{{survey_url}}&goal=1" style="text-align: center; text-decoration: none;">
+                            <div style="padding: 0.6rem 2rem; background-color: #DDF6F4; color: #05C6B4; border: 1px solid #05C6B4; border-right: none; border-radius: 4px 0 0 4px;">1</div>
+                          </a>
+                        </td>
+                        <td>
+                          <a href="{{survey_url}}&goal=2" style="text-align: center; text-decoration: none;">
+                            <div style="padding: 0.6rem 2rem; background-color: #DDF6F4; color: #05C6B4; border: 1px solid #05C6B4; border-right: none;">2</div>
+                          </a>
+                        </td>
+                        <td>
+                          <a href="{{survey_url}}&goal=3" style="text-align: center; text-decoration: none;">
+                            <div style="padding: 0.6rem 2rem; background-color: #DDF6F4; color: #05C6B4; border: 1px solid #05C6B4; border-right: none;">3</div>
+                          </a>
+                        </td>
+                        <td>
+                          <a href="{{survey_url}}&goal=4" style="text-align: center; text-decoration: none;">
+                            <div style="padding: 0.6rem 2rem; background-color: #DDF6F4; color: #05C6B4; border: 1px solid #05C6B4; border-right: none;">4</div>
+                          </a>
+                        </td>
+                        <td>
+                          <a href="{{survey_url}}&goal=5" style="text-align: center; text-decoration: none;">
+                            <div style="padding: 0.6rem 2rem; background-color: #DDF6F4; color: #05C6B4; border: 1px solid #05C6B4; border-radius: 0 4px 4px 0;">5</div>
+                          </a>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <table width="100%">
+                    <tbody>
+                      <tr>
+                        <td>
+                          <small style="font-size: 0.8rem; color: #05C6B4">{% trans "Not at all" %}</small>
+                        </td>
+                        <td style="text-align: right;">
+                          <small style="font-size: 0.8rem; color: #05C6B4">{% trans "Completely!" %}</small>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+      </tr>
+    {% endif %}
     <tr>
       <td>
-        <table align="center" align="center" style="margin-top: 2rem; margin-bottom: 2rem;">
-          <tbody>
-            <tr>
-              <td>
-                <table border="0" cellspacing="0" cellpadding="0" >
-                  <tbody>
-                    <tr>
-                      <td>
-                        <a href="{{survey_url}}&goal=1" style="text-align: center; text-decoration: none;">
-                          <div style="padding: 0.6rem 2rem; background-color: #DDF6F4; color: #05C6B4; border: 1px solid #05C6B4; border-right: none; border-radius: 4px 0 0 4px;">1</div>
-                        </a>
-                      </td>
-                      <td>
-                        <a href="{{survey_url}}&goal=2" style="text-align: center; text-decoration: none;">
-                          <div style="padding: 0.6rem 2rem; background-color: #DDF6F4; color: #05C6B4; border: 1px solid #05C6B4; border-right: none;">2</div>
-                        </a>
-                      </td>
-                      <td>
-                        <a href="{{survey_url}}&goal=3" style="text-align: center; text-decoration: none;">
-                          <div style="padding: 0.6rem 2rem; background-color: #DDF6F4; color: #05C6B4; border: 1px solid #05C6B4; border-right: none;">3</div>
-                        </a>
-                      </td>
-                      <td>
-                        <a href="{{survey_url}}&goal=4" style="text-align: center; text-decoration: none;">
-                          <div style="padding: 0.6rem 2rem; background-color: #DDF6F4; color: #05C6B4; border: 1px solid #05C6B4; border-right: none;">4</div>
-                        </a>
-                      </td>
-                      <td>
-                        <a href="{{survey_url}}&goal=5" style="text-align: center; text-decoration: none;">
-                          <div style="padding: 0.6rem 2rem; background-color: #DDF6F4; color: #05C6B4; border: 1px solid #05C6B4; border-radius: 0 4px 4px 0;">5</div>
-                        </a>
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <table width="100%">
-                  <tbody>
-                    <tr>
-                      <td>
-                        <small style="font-size: 0.8rem; color: #05C6B4">Not at all</small>
-                      </td>
-                      <td style="text-align: right;">
-                        <small style="font-size: 0.8rem; color: #05C6B4">Completely!</small>
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <p>Cheers,</p>
-        <p>The P2PU Team</p>
+        <p>{% trans "Cheers" %},</p>
+        <p>{% trans "The P2PU Team" %}</p>
       </td>
 
     </tr>
   </tbody>
 </table>
-{% endblocktrans %}
 
 {% endblock %}

--- a/templates/studygroups/email/learner_survey_reminder.txt
+++ b/templates/studygroups/email/learner_survey_reminder.txt
@@ -1,14 +1,11 @@
 {% load i18n %}
-{% blocktrans %}
-Hi {{learner_name}},
+{% blocktrans %}Hi {{learner_name}},
 
-Can you take a few minutes to let us know how your learning circle went? Your feedback - the good and the bad - will improve the learning circle program for learners and facilitators around the world.
+Can you take a few minutes to let us know how your learning circle is going? Your feedback - the good and the bad - will improve the learning circle program for learners and facilitators around the world.
 
 Share your feedback by clicking this link: {{survey_url}}
 
-Thank you for being part of the P2PU community, and we look forward to hearing from you!
-
-{% endblocktrans %}
+Thank you for being part of the P2PU community, and we look forward to hearing from you!{% endblocktrans %}
 
 {% trans "Cheers" %},
 {% trans "The P2PU Team" %}


### PR DESCRIPTION
- Send learner surveys 1 week earlier
- Stop sending empty weekly updates to team organizers
- Only ask for 'other goal' on learner signup form if they select 'other' in the dropdown