### PR TITLE
add indentation to facilitator survey reminder email

### DIFF
--- a/templates/studygroups/email/facilitator-survey-reminder.html
+++ b/templates/studygroups/email/facilitator-survey-reminder.html
@@ -1,6 +1,13 @@
 {% extends 'email_base.html' %}
 {% block body %}
 {% load i18n %}
+<style>
+  .indented {
+    padding: 10px;
+    padding-left: 30px;
+    border-left: 6px solid #D3D8E6;
+  }
+</style>
 
 <table>
   <tbody>
@@ -13,12 +20,12 @@
 
         <p>Can you remind your learning circle participants to reply to the survey? Feel free to copy the text below and modify it:</p>
         {% endblocktrans %}
-        <hr>
-        <p>{% trans "Hi there" %},</p>
-        <p>{% trans "Can you take a few minutes to let me know how your learning circle is going? Your feedback - the good and the bad - will improve the learning circle program for learners and facilitators around the world." %}</p>
-        <p>Share your feedback here: <a href="{{ learner_survey_url }}">{{ learner_survey_url }}</a></p>
-        <p>{% trans "Thank you!" %}</p>
-        <hr>
+        <div class="indented">
+          <p>{% trans "Hi there" %},</p>
+          <p>{% trans "Can you take a few minutes to let me know how your learning circle is going? Your feedback - the good and the bad - will improve the learning circle program for learners and facilitators around the world." %}</p>
+          <p>{% trans "Share your feedback here:" %} <a href="{{ learner_survey_url }}">{{ learner_survey_url }}</a></p>
+          <p>{% trans "Thank you!" %}</p>
+        </div>
 
           {% if learners_without_survey_responses is not None %}
           <p>{% trans "These are the participants who haven't responded yet, according to our records:" %}
@@ -30,9 +37,7 @@
           {% endif %}
 
         {% if facilitator_survey_url is not None %}
-        {% blocktrans %}
-          <p>As a reminder, this is the link for you to leave your own feedback: <a href="{{ facilitator_survey_url }}">{{ facilitator_survey_url }}</a></p>
-        {% endblocktrans %}
+          <p>{% trans "As a reminder, this is the link for you to leave your own feedback:" %} <a href="{{ facilitator_survey_url }}">{{ facilitator_survey_url }}</a></p>
         {% endif %}
 
         <p>{% trans "Cheers" %},</p>

--- a/templates/studygroups/email/facilitator-survey-reminder.txt
+++ b/templates/studygroups/email/facilitator-survey-reminder.txt
@@ -7,19 +7,29 @@ Hi {{ facilitator_name }},
 
 The survey we sent to your learning circle participants has {{ learner_responses_count }} response{{ learner_responses_count|pluralize }} so far. Here’s a preview of what your learning circle report currently looks like: {{ report_url }}
 
-Can you remind the following people to reply to this survey? You can share this link with them: {{ learner_survey_url }}
+Can you remind your learning circle participants to reply to the survey? Feel free to copy the text below and modify it:
+
 {% endblocktrans %}
+---
+
+{% trans "Hi there" %},
+{% trans "Can you take a few minutes to let me know how your learning circle is going? Your feedback - the good and the bad - will improve the learning circle program for learners and facilitators around the world." %}
+{% trans "Share your feedback here:" %} {{ learner_survey_url }}
+{% trans "Thank you!" %}
+
+---
+
+
 
 {% if learners_without_survey_responses %}
+{% trans "These are the participants who haven't responded yet, according to our records:" %}
   {% for learner in learners_without_survey_responses %}
     - {{ learner.name }} - {{ learner.email }}
   {% endfor %}
 {% endif %}
 
 {% if facilitator_survey_url is not None %}
-{% blocktrans %}
-As a reminder, this is the link for you to leave your own feedback: {{ facilitator_survey_url }}
-{% endblocktrans %}
+{% trans "As a reminder, this is the link for you to leave your own feedback:" %} {{ facilitator_survey_url }}
 {% endif %}
 
 {% trans "Cheers" %},


### PR DESCRIPTION
Looks like this now:
![screen shot 2018-11-04 at 3 19 39 pm](https://user-images.githubusercontent.com/10519011/47969442-bf33ac00-e045-11e8-8ede-c0050f5517d5.png)
