### PR TITLE
Allow goals met to be null so that editing in the admin interface works

### DIFF
--- a/studygroups/models.py
+++ b/studygroups/models.py
@@ -284,7 +284,7 @@ class Application(LifeTimeTrackingModel):
     mobile = models.CharField(max_length=20, blank=True)
     mobile_opt_out_at = models.DateTimeField(blank=True, null=True)
     signup_questions = models.TextField(default='{}')
-    goal_met = models.SmallIntegerField(null=True)
+    goal_met = models.SmallIntegerField(blank=True, null=True)
     accepted_at = models.DateTimeField(blank=True, null=True)
     uuid = models.UUIDField(default=uuid.uuid4, editable=False, unique=True)
 


### PR DESCRIPTION
- Fix bug with goals met being required for all signups when editing a study group in the admin interface.