### PR TITLE
fix truncate_label to truncate_legend

### DIFF
--- a/studygroups/charts.py
+++ b/studygroups/charts.py
@@ -829,7 +829,7 @@ class LearningCircleMeetingsChart():
 class LearningCircleCountriesChart():
 
     def __init__(self, start_date, report_date, **kwargs):
-        self.chart = pygal.Pie(style=custom_style(), inner_radius=.4, truncate_label=-1, **kwargs)
+        self.chart = pygal.Pie(style=custom_style(), inner_radius=.4, truncate_legend=-1, **kwargs)
         self.start_date = start_date
         self.report_date = report_date
 


### PR DESCRIPTION
This fixes the issue in the community digest of the country names getting truncated with the rectangle character. 

<img width="716" alt="screen shot 2019-02-04 at 3 19 19 pm" src="https://user-images.githubusercontent.com/10519011/52234704-4801f400-2890-11e9-94f6-153768f18433.png">
