### PR TITLE
add open sans web font to base email template

### DIFF
--- a/templates/email_base.html
+++ b/templates/email_base.html
@@ -46,6 +46,7 @@
     <meta charset="utf-8">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons"
         rel="stylesheet">
+      <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width">
   </head>


### PR DESCRIPTION
I realized I forgot to include the web font for Open Sans in the email template when I was investigating why some of the community digest text is showing up as Roboto in Gmail. I don't think this will fix the Roboto issue but it should be there anyway.