### PR TITLE
Bugfix 2019-02-05

### DIFF
--- a/studygroups/admin.py
+++ b/studygroups/admin.py
@@ -21,6 +21,7 @@ class StudyGroupAdmin(admin.ModelAdmin):
 
 class TeamMembershipInline(admin.TabularInline):
     model = TeamMembership
+    raw_id_fields = ("user",)
 
 class TeamAdmin(admin.ModelAdmin):
     list_display = ('name', 'page_slug')


### PR DESCRIPTION
Use raw_id_fields for TeamMembership inline to avoid select field with *all* users.