### PR TITLE
use latest version of p2pu-search-cards to fix styling bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "moment": "^2.18.1",
     "node-sass": "^4.9.3",
     "p2pu-input-fields": "^0.5.17",
-    "p2pu-search-cards": "^0.12.0",
+    "p2pu-search-cards": "^0.13.2",
     "p2pu-theme": "^1.1.2",
     "places.js": "^1.4.18",
     "promise-polyfill": "^6.0.2",


### PR DESCRIPTION
Before: 
<img width="733" alt="Screen Shot 2019-05-15 at 5 52 02 PM" src="https://user-images.githubusercontent.com/10519011/57812154-33a87f80-773a-11e9-9118-14fa99df0d99.png">

After:
<img width="725" alt="Screen Shot 2019-05-15 at 5 53 52 PM" src="https://user-images.githubusercontent.com/10519011/57812224-6ce0ef80-773a-11e9-8223-9f90e9ded47a.png">
