### PR TITLE
revert changes to reset password email template

### DIFF
--- a/templates/registration/password_reset_email.html
+++ b/templates/registration/password_reset_email.html
@@ -1,2 +1,2 @@
 {% load i18n %}{% url 'password_reset_confirm' uidb64=uid token=token as reset_url%}{% blocktrans %}Someone asked for a password reset for email {{ email }}. Follow the link below to complete the password reset:
-{{ PROTOCOL}}://{{ DOMAIN }}{{reset_url}}{% endblocktrans %}
+{{ protocol }}://{{ domain }}{{reset_url}}{% endblocktrans %}


### PR DESCRIPTION
Fixes #450 but tbh I'm not 100% sure why, I think because the view is from django.contrib.auth and uses the default `render_to_string` instead of `render_to_string_ctx`? In any case the template isn't getting the variables from the context processor.

So this commit is just undoing the changes to the template from [this commit](https://github.com/p2pu/learning-circles/commit/1a73b73579caa4d088e9c5d74ee6e67e33204225). 

